### PR TITLE
ref: rewrite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,10 @@ once_cell = "1.19.0"
 serde_json = "1.0.117"
 serde = { version = "1.0", features = ["derive"] }
 
-axum = {version = "0.6.0", optional=true, features = ["ws"]}
+axum = {version = "0.6.0", features = ["ws"], optional=true}
 tokio = { version = "1.0", features = ["full"] , optional=true}
-wasm-bindgen-futures = "0.4"
 uuid = {version =  "1.8.0", features = ["v4"], optional=true}
+wasm-bindgen-futures = "0.4"
 
 futures-util = "0.3"
 futures = "0.3"

--- a/src/common.rs
+++ b/src/common.rs
@@ -3,6 +3,29 @@ use std::fmt::{self, Display, Formatter};
 use std::num::ParseFloatError;
 use std::str::FromStr;
 
+#[cfg(feature = "server")]
+use axum::extract::ws::Message;
+
+#[derive(Serialize, Deserialize)]
+pub enum SocketMessage {
+    User(String),
+    Info(String),
+}
+
+impl SocketMessage {
+    #[cfg(feature = "server")]
+    pub fn user_msg(msg: String) -> Message {
+        let s = serde_json::to_string(&Self::User(msg)).unwrap();
+        Message::Text(s)
+    }
+
+    #[cfg(feature = "server")]
+    pub fn info_msg(msg: String) -> Message {
+        let s = serde_json::to_string(&Self::Info(msg)).unwrap();
+        Message::Text(s)
+    }
+}
+
 #[derive(PartialEq, Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct Scores {
     pub o: f32,

--- a/src/common.rs
+++ b/src/common.rs
@@ -3,7 +3,7 @@ use std::fmt::{self, Display, Formatter};
 use std::num::ParseFloatError;
 use std::str::FromStr;
 
-#[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
+#[derive(PartialEq, Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct Scores {
     pub o: f32,
     pub c: f32,

--- a/src/common.rs
+++ b/src/common.rs
@@ -6,6 +6,7 @@ use std::str::FromStr;
 #[cfg(feature = "server")]
 use axum::extract::ws::Message;
 
+/// The type that gets sent from server to client through socket.
 #[derive(Serialize, Deserialize)]
 pub enum SocketMessage {
     User(String),

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -50,34 +50,32 @@ impl State {
     }
 }
 
-impl Scores {
-    fn from_form(form: &FormData) -> Option<Self> {
-        let data = form.values();
+fn scores_from_formdata(form: &FormData) -> Option<Scores> {
+    let data = form.values();
 
-        let o: f32 = data.get("o")?.as_value().parse().ok()?;
-        let c: f32 = data.get("c")?.as_value().parse().ok()?;
-        let e: f32 = data.get("e")?.as_value().parse().ok()?;
-        let a: f32 = data.get("a")?.as_value().parse().ok()?;
-        let n: f32 = data.get("n")?.as_value().parse().ok()?;
+    let o: f32 = data.get("o")?.as_value().parse().ok()?;
+    let c: f32 = data.get("c")?.as_value().parse().ok()?;
+    let e: f32 = data.get("e")?.as_value().parse().ok()?;
+    let a: f32 = data.get("a")?.as_value().parse().ok()?;
+    let n: f32 = data.get("n")?.as_value().parse().ok()?;
 
-        if !(0. ..=100.).contains(&o) {
-            return None;
-        }
-        if !(0. ..=100.).contains(&c) {
-            return None;
-        }
-        if !(0. ..=100.).contains(&e) {
-            return None;
-        }
-        if !(0. ..=100.).contains(&a) {
-            return None;
-        }
-        if !(0. ..=100.).contains(&n) {
-            return None;
-        }
-
-        Some(Self { o, c, e, a, n })
+    if !(0. ..=100.).contains(&o) {
+        return None;
     }
+    if !(0. ..=100.).contains(&c) {
+        return None;
+    }
+    if !(0. ..=100.).contains(&e) {
+        return None;
+    }
+    if !(0. ..=100.).contains(&a) {
+        return None;
+    }
+    if !(0. ..=100.).contains(&n) {
+        return None;
+    }
+
+    Some(Scores { o, c, e, a, n })
 }
 
 #[derive(Clone, Routable, Debug, PartialEq)]
@@ -239,21 +237,22 @@ fn Home() -> Element {
     let state = use_context::<State>();
 
     rsx! {
-            form { onsubmit:  move |event| {
-                let scores = Scores::from_form(&event.data());
-                if let Some(scores) = scores {
-                    state.set_scores(scores);
-                    navigator.replace(Route::Chat{});
-                } else {
-                    navigator.replace(Route::Invalid {});
-                }
-            },
+    form { onsubmit:  move |event| {
+         match scores_from_formdata(&event.data()) {
+             Some(scores) => {
+                 state.set_scores(scores);
+                 navigator.replace(Route::Chat{});
+             }
+             None => {
+                 navigator.replace(Route::Invalid {});
+             }
 
+         }
 
-
+    },
     div { class: "form-group",
-                    label { "Openness: " }
-                    input { name: "o", value: "50"}
+                label { "Openness: " }
+                input { name: "o", value: "50"}
                 }
                 div { class: "form-group",
                     label { "Conscientiousness: " }
@@ -273,9 +272,9 @@ fn Home() -> Element {
                 }
                 div { class: "form-group",
                     input { r#type: "submit", value: "Submit" }
-                }
             }
         }
+    }
 }
 
 #[derive(PartialEq, Clone)]

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -20,6 +20,12 @@ struct State {
     inner: Arc<Mutex<InnerState>>,
 }
 
+#[derive(Default)]
+struct InnerState {
+    scores: Option<Scores>,
+    socket: Option<WebSocket>,
+}
+
 impl State {
     fn set_scores(&self, scores: Scores) {
         self.inner.lock().unwrap().scores = Some(scores);
@@ -42,12 +48,6 @@ impl State {
             false
         }
     }
-}
-
-#[derive(Default)]
-struct InnerState {
-    scores: Option<Scores>,
-    socket: Option<WebSocket>,
 }
 
 impl Scores {
@@ -173,7 +173,6 @@ fn Chat() -> Element {
 
     use_effect({
         let state = state.clone();
-        let messages = messages;
         move || {
             let state = state.clone();
             spawn_local(async move {
@@ -217,7 +216,7 @@ fn Chat() -> Element {
 }
 
 fn App() -> Element {
-    use_context_provider(|| State::default());
+    use_context_provider(State::default);
     rsx!(Router::<Route> {})
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 #[cfg(not(feature = "server"))]
 mod frontend;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,9 @@ mod server;
 mod common;
 
 #[cfg(feature = "server")]
-fn main() {
-    server::run();
+#[tokio::main]
+async fn main() {
+    server::run().await;
 }
 
 #[cfg(not(feature = "server"))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 #[cfg(feature = "server")]
 mod server;
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,59 +1,18 @@
 use axum::{
     extract::ws::{WebSocket, WebSocketUpgrade},
-    response::{IntoResponse, Json},
+    extract::Extension,
+    extract::Path,
+    response::IntoResponse,
     routing::get,
-    routing::post,
     Router,
 };
 
 use crate::common::Scores;
-use axum::extract::Path;
 use futures_util::StreamExt;
-use once_cell::sync::Lazy;
-use serde::Serialize;
-use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
-use tokio::sync::oneshot;
 use tower_http::cors::{Any, CorsLayer};
-use uuid::Uuid;
-
-type UserId = Uuid;
 
 const PAIR_WINDOW_MILLIS: u64 = 1000;
-
-static STATE: Lazy<Arc<Mutex<State>>> = Lazy::new(|| {
-    let s = State::new();
-    Arc::new(Mutex::new(s))
-});
-
-/// Bi-directional mapping of all paired up users.
-#[derive(Clone, Default)]
-struct Pairs {
-    inner: HashMap<UserId, UserId>,
-}
-
-impl Pairs {
-    fn insert(&mut self, a: UserId, b: UserId) {
-        self.inner.insert(a, b);
-        self.inner.insert(b, a);
-    }
-
-    fn remove(&mut self, id: UserId) {
-        let peer = self.get(id);
-        self.inner.remove(&id);
-        self.inner.remove(&peer);
-    }
-
-    fn get(&self, id: UserId) -> UserId {
-        self.inner.get(&id).unwrap().to_owned()
-    }
-}
-
-/// Response from server when frontend requests a peer.
-#[derive(Serialize)]
-struct PairResponse {
-    peer_id: String,
-}
 
 /// Holds the client-server connections between two peers.
 struct Connection {
@@ -68,6 +27,7 @@ impl Connection {
 
     /// Handles sending messages from one peer to another.
     async fn run(mut self) {
+        eprintln!("communication starting between a pair");
         loop {
             tokio::select! {
                 Some(message) = self.left.next() => {
@@ -104,27 +64,17 @@ impl Connection {
     }
 }
 
-#[derive(Default)]
-struct State {
-    // The users who have clicked submit but have not yet been assigned a peer.
-    users_waiting: Arc<Mutex<Vec<WaitingUser>>>,
-    // Map of all pairs that have yet to establish a connection.
-    pairs: Pairs,
-    /// There's a brief period where one user has established a connection
-    /// but his peer have not.
-    cons: HashMap<UserId, WebSocket>,
-}
-
 struct WaitingUser {
-    id: UserId,
-    callback: oneshot::Sender<UserId>,
     score: Scores,
+    socket: WebSocket,
 }
 
 /// If 2 or more users are present, it'll pop the longest-waiting user along with
 /// another user who has the closest personality.
 fn pair_pop(users: &mut Vec<WaitingUser>) -> Option<(WaitingUser, WaitingUser)> {
-    if users.len() < 2 {
+    let len = users.len();
+    eprintln!("users waiting {}", len);
+    if len < 2 {
         return None;
     }
 
@@ -144,119 +94,82 @@ fn pair_pop(users: &mut Vec<WaitingUser>) -> Option<(WaitingUser, WaitingUser)> 
 
     let right = users.remove(right_index);
 
+    eprintln!("two users paired up!");
     Some((left, right))
+}
+
+#[derive(Default, Clone)]
+struct State {
+    // The users who have clicked submit but have not yet been assigned a peer.
+    users_waiting: Arc<Mutex<Vec<WaitingUser>>>,
 }
 
 impl State {
     fn new() -> Self {
-        let s = Self::default();
-        s.start_pairing();
-        s
+        Self::default()
     }
 
     /// Queues a user for pairing. Await the oneshot receiver and
     /// you will receive the peer ID when pairing has completed.
-    fn queue(&self, id: UserId, score: Scores) -> oneshot::Receiver<UserId> {
-        let (tx, rx) = oneshot::channel();
-        let user = WaitingUser {
-            id,
-            callback: tx,
-            score,
-        };
+    fn queue(&self, score: Scores, socket: WebSocket) {
+        println!("user queued ");
+        let user = WaitingUser { score, socket };
         self.users_waiting.lock().unwrap().push(user);
-        rx
     }
 
-    fn start_pairing(&self) {
+    async fn start_pairing(&self) {
+        eprintln!("pairing started");
         let users = Arc::clone(&self.users_waiting);
-
-        std::thread::spawn(move || loop {
-            {
-                let mut lock = users.lock().unwrap();
-
-                while let Some((left, right)) = pair_pop(&mut lock) {
-                    left.callback.send(right.id).unwrap();
-                    right.callback.send(left.id).unwrap();
+        tokio::spawn(async move {
+            loop {
+                {
+                    let mut lock = users.lock().unwrap();
+                    while let Some((left, right)) = pair_pop(&mut lock) {
+                        tokio::spawn(async move {
+                            Connection::new(left.socket, right.socket).run().await;
+                        });
+                    }
                 }
+                tokio::time::sleep(std::time::Duration::from_millis(PAIR_WINDOW_MILLIS)).await;
             }
-            std::thread::sleep(std::time::Duration::from_millis(PAIR_WINDOW_MILLIS));
         });
     }
 }
 
-// Returns the user with the closest personality score to the given scores argument.
-pub async fn pair_handler(Json(scores): Json<Scores>) -> impl IntoResponse {
-    let user_id = Uuid::new_v4();
-
-    println!("Generated UUID for new user: {}", user_id);
-
-    let peer_id = {
-        let state = STATE.lock().unwrap();
-        state.queue(user_id, scores)
-    };
-
-    let peer_id = peer_id.await.unwrap();
-    {
-        let mut state = STATE.lock().unwrap();
-        state.pairs.insert(user_id, peer_id);
-    }
-    let peer_id = peer_id.to_string();
-    Json(PairResponse { peer_id })
-}
-
-/// Sets up a websocket communication with the user and its peer.
-///
-/// If the peer has already connected, a [`Connection`] is set up and communication can start.
-/// If the peer has yet to connect, the caller's websocket is saved and waits for the peer to
-/// connect.
-pub async fn connect_handler(
+async fn pair_handler(
+    Path(scores): Path<String>,
     ws: WebSocketUpgrade,
-    Path(peer_id): Path<String>,
+    Extension(state): Extension<Arc<State>>,
 ) -> impl IntoResponse {
-    eprintln!("attempting connection with: {}", &peer_id);
-    let state = STATE.clone();
-
-    let peer_id: UserId = peer_id.parse().unwrap();
-    let caller_id = state.lock().unwrap().pairs.get(peer_id);
-
+    eprintln!("pair handling!");
+    let scores: Scores = scores.parse().unwrap();
     ws.on_upgrade(move |socket| {
         let state = state.clone();
         async move {
-            let mut state = state.lock().unwrap();
-
-            match state.cons.remove(&caller_id) {
-                None => {
-                    state.cons.insert(peer_id, socket);
-                }
-                Some(peer_socket) => {
-                    state.pairs.remove(peer_id);
-                    tokio::spawn(async move {
-                        Connection::new(peer_socket, socket).run().await;
-                    });
-                }
-            }
+            let state = state.clone();
+            state.queue(scores, socket);
         }
     })
 }
 
-pub fn run() {
-    eprintln!("starting server");
+pub async fn run() {
+    let state = State::new();
+    state.start_pairing().await;
+
+    eprintln!("starting server ");
     let cors = CorsLayer::new()
         .allow_origin(Any)
         .allow_methods(Any)
         .allow_headers(Any);
 
     let app = Router::new()
-        .route("/pair", post(pair_handler))
-        .route("/connect/:id", get(connect_handler))
-        .layer(cors);
+        .route("/pair/:scores", get(pair_handler))
+        .layer(cors)
+        .layer(Extension(Arc::new(state)));
 
     let addr = "127.0.0.1:3000".parse().unwrap();
-    let runtime = tokio::runtime::Runtime::new().unwrap();
-    runtime.block_on(async {
-        axum::Server::bind(&addr)
-            .serve(app.into_make_service())
-            .await
-            .unwrap();
-    });
+    axum::Server::bind(&addr)
+        .serve(app.into_make_service())
+        .await
+        .unwrap();
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -117,7 +117,7 @@ fn pair_pop(users: &mut Vec<WaitingUser>) -> Option<(WaitingUser, WaitingUser)> 
 
 #[derive(Default, Clone)]
 struct State {
-    // The users who have clicked submit but have not yet been assigned a peer.
+    // Users waiting to be matched with a peer.
     users_waiting: Arc<Mutex<Vec<WaitingUser>>>,
 }
 
@@ -129,7 +129,7 @@ impl State {
     /// Queues a user for pairing. Await the oneshot receiver and
     /// you will receive the peer ID when pairing has completed.
     fn queue(&self, score: Scores, socket: WebSocket) {
-        println!("user queued ");
+        eprintln!("user queued ");
         let user = WaitingUser { score, socket };
         self.users_waiting.lock().unwrap().push(user);
     }

--- a/src/styles.css
+++ b/src/styles.css
@@ -13,12 +13,18 @@
 }
 
 .message.me {
-    background-color: #daf1da; /* Light green background from you */
+    background-color: #42b4d6;
+    text-align: left;
+}
+
+
+.message.info {
+    background-color: #c5c9c7;
     text-align: left;
 }
 
 .message.peer {
-    background-color: #f1f1f1; /* Light grey from peer */
+    background-color: #5cdb91; 
     text-align: left;
 }
 


### PR DESCRIPTION
* Pairing and connecting is now done in same request, this means we don't need intermediate queues on backend, greatly simplifying the code.
* New `State` object in frontend, I realized this is easier to work in than shoehorning all the arguments into the url
* New `info` sender at chat, allowing the backend to send custom messages to the users