### PR TITLE
fix(common): Include config str in frontend binary

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1,9 +1,7 @@
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
-use std::fs;
 use std::num::ParseFloatError;
-use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -16,17 +14,30 @@ pub struct Config {
 }
 
 impl Config {
+    /// Loads the config file.
+    ///
+    /// Behaviour is different between backend and frontend.
+    /// In the backend we load the config from file, creating new if it doesn't exist.
+    ///
+    /// The frontend however, needs to package the config into the binary since it doesn't
+    /// have access to the backend's file system. We use include_str which will make the program
+    /// fail to compile if we haven't configured a config yet. This means in practice that if you
+    /// didn't manually add a config file, you need to run the backend at least once before
+    /// you build the frontend.
     pub fn load() -> Self {
-        let path = PathBuf::from("config.toml");
+        #[cfg(not(feature = "server"))]
+        let config_str = include_str!("../config.toml");
+        #[cfg(feature = "server")]
+        let config_str = {
+            let config_path = std::path::PathBuf::from("config.toml");
+            if !config_path.exists() {
+                let s: String = toml::to_string(&Self::default()).unwrap();
+                std::fs::write(&config_path, s.as_bytes()).unwrap();
+            }
+            std::fs::read_to_string(&config_path).unwrap()
+        };
 
-        if !path.exists() {
-            let s: String = toml::to_string(&Self::default()).unwrap();
-            fs::write(&path, s.as_bytes()).unwrap();
-        }
-
-        let s: String = fs::read_to_string(&path).unwrap();
-
-        toml::from_str(&s).unwrap()
+        toml::from_str(&config_str).unwrap()
     }
 }
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -9,7 +9,7 @@ pub static CONFIG: Lazy<Arc<Config>> = Lazy::new(|| Arc::new(Config::load()));
 
 #[derive(Serialize, Deserialize)]
 pub struct Config {
-    pub backend_ip: String,
+    pub local: bool,
     pub pair_interval_millis: u64,
 }
 
@@ -39,12 +39,20 @@ impl Config {
 
         toml::from_str(&config_str).unwrap()
     }
+
+    pub fn server_address(&self) -> &'static str {
+        if self.local {
+            "ws://127.0.0.1:3000"
+        } else {
+            "wss://oceanchat.app"
+        }
+    }
 }
 
 impl Default for Config {
     fn default() -> Self {
         Config {
-            backend_ip: "127.0.0.1".to_string(),
+            local: true,
             pair_interval_millis: 1000,
         }
     }

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -94,7 +94,7 @@ async fn connect_to_peer(
     mut messages: Signal<Vec<Message>>,
 ) -> Result<WebSocket, String> {
     log_to_console("Starting to connect");
-    let url = format!("ws://{}:3000/pair/{}", &CONFIG.backend_ip, scores);
+    let url = format!("{}/pair/{}", CONFIG.server_address(), scores);
 
     // Attempt to create the WebSocket
     let ws = web_sys::WebSocket::new(&url).map_err(|err| {

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -2,6 +2,7 @@
 
 use crate::common::Scores;
 use crate::common::SocketMessage;
+use crate::common::CONFIG;
 use dioxus::prelude::*;
 use std::sync::{Arc, Mutex};
 use wasm_bindgen::prelude::*;
@@ -93,7 +94,7 @@ async fn connect_to_peer(
     mut messages: Signal<Vec<Message>>,
 ) -> Result<WebSocket, String> {
     log_to_console("Starting to connect");
-    let url = format!("ws://127.0.0.1:3000/pair/{}", scores);
+    let url = format!("ws://{}:3000/pair/{}", &CONFIG.backend_ip, scores);
 
     // Attempt to create the WebSocket
     let ws = web_sys::WebSocket::new(&url).map_err(|err| {

--- a/src/server.rs
+++ b/src/server.rs
@@ -47,6 +47,7 @@ impl Connection {
                             break;
                         },
                         Message::Text(msg) => {
+                            eprintln!("right->left: {}", &msg);
                             if left_tx.send(SocketMessage::user_msg(msg)).await.is_err() {
                                 eprintln!("Failed to send message to right");
                                 break;
@@ -62,6 +63,7 @@ impl Connection {
                             break;
                         },
                         Message::Text(msg) => {
+                            eprintln!("left->right: {}", &msg);
                             if right_tx.send(SocketMessage::user_msg(msg)).await.is_err() {
                                 eprintln!("Failed to send message to right");
                                 break;

--- a/src/server.rs
+++ b/src/server.rs
@@ -186,7 +186,7 @@ pub async fn run() {
         .layer(cors)
         .layer(Extension(Arc::new(state)));
 
-    let addr = "127.0.0.1:3000".parse().unwrap();
+    let addr = "0.0.0.0:3000".parse().unwrap();
     axum::Server::bind(&addr)
         .serve(app.into_make_service())
         .await

--- a/src/server.rs
+++ b/src/server.rs
@@ -90,9 +90,7 @@ struct WaitingUser {
 /// If 2 or more users are present, it'll pop the longest-waiting user along with
 /// another user who has the closest personality.
 fn pair_pop(users: &mut Vec<WaitingUser>) -> Option<(WaitingUser, WaitingUser)> {
-    let len = users.len();
-    eprintln!("users waiting {}", len);
-    if len < 2 {
+    if users.len() < 2 {
         return None;
     }
 
@@ -112,7 +110,10 @@ fn pair_pop(users: &mut Vec<WaitingUser>) -> Option<(WaitingUser, WaitingUser)> 
 
     let right = users.remove(right_index);
 
-    eprintln!("two users paired up!");
+    eprintln!(
+        "two users paired up! remaining users waiting: {}",
+        users.len()
+    );
     Some((left, right))
 }
 
@@ -130,9 +131,11 @@ impl State {
     /// Queues a user for pairing. Await the oneshot receiver and
     /// you will receive the peer ID when pairing has completed.
     fn queue(&self, score: Scores, socket: WebSocket) {
-        eprintln!("user queued ");
+        eprintln!("queing user..");
         let user = WaitingUser { score, socket };
-        self.users_waiting.lock().unwrap().push(user);
+        let mut users = self.users_waiting.lock().unwrap();
+        users.push(user);
+        eprintln!("users waiting: {}", users.len());
     }
 
     async fn start_pairing(&self) {


### PR DESCRIPTION
We cant load the config from file in the frontend code since the client doesnt have access to the backend's file system. include_str! will package the config into the frontend's binary.

