### PR TITLE
feat: Send peer's scores back to client

### DIFF
--- a/src/client/chat.rs
+++ b/src/client/chat.rs
@@ -21,13 +21,11 @@ async fn connect_to_peer(
     let url = format!("{}/pair/{}", CONFIG.server_address(), scores);
 
     // Attempt to create the WebSocket
-    let ws = web_sys::WebSocket::new(&url)
-        .map_err(|err| {
-            let err_msg = format!("Failed to create WebSocket: {:?}", err);
-            log_to_console(&err_msg);
-            err_msg
-        })
-        .unwrap();
+    let ws = web_sys::WebSocket::new(&url).map_err(|err| {
+        let err_msg = format!("Failed to create WebSocket: {:?}", err);
+        log_to_console(&err_msg);
+        err_msg
+    })?;
     log_to_console("WebSocket created");
 
     // Handle WebSocket open event

--- a/src/common.rs
+++ b/src/common.rs
@@ -66,6 +66,7 @@ use axum::extract::ws::Message;
 pub enum SocketMessage {
     User(String),
     Info(String),
+    PeerScores(Scores),
 }
 
 impl SocketMessage {
@@ -78,6 +79,12 @@ impl SocketMessage {
     #[cfg(feature = "server")]
     pub fn info_msg(msg: String) -> Message {
         let s = serde_json::to_string(&Self::Info(msg)).unwrap();
+        Message::Text(s)
+    }
+
+    #[cfg(feature = "server")]
+    pub fn peer_scores(scores: Scores) -> Message {
+        let s = serde_json::to_string(&Self::PeerScores(scores)).unwrap();
         Message::Text(s)
     }
 }

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -23,12 +23,17 @@ struct State {
 #[derive(Default)]
 struct InnerState {
     scores: Option<Scores>,
+    peer_scores: Option<Scores>,
     socket: Option<WebSocket>,
 }
 
 impl State {
     fn set_scores(&self, scores: Scores) {
         self.inner.lock().unwrap().scores = Some(scores);
+    }
+
+    fn set_peer_scores(&self, scores: Scores) {
+        self.inner.lock().unwrap().peer_scores = Some(scores);
     }
 
     fn scores(&self) -> Option<Scores> {

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -41,6 +41,7 @@ impl Connection {
                             break;
                         },
                         Message::Text(msg) => {
+                            tracing::info!("right->left: {}", &msg);
                             if left_tx.send(SocketMessage::user_msg(msg)).await.is_err() {
                                 tracing::error!("Failed to send message to left");
                                 break;
@@ -56,6 +57,7 @@ impl Connection {
                             break;
                         },
                         Message::Text(msg) => {
+                            tracing::info!("left->right: {}", &msg);
                             if right_tx.send(SocketMessage::user_msg(msg)).await.is_err() {
                                 tracing::error!("Failed to send message to right");
                                 break;

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1,16 +1,17 @@
 use crate::common::SocketMessage;
-use axum::{extract::ws::Message, extract::ws::WebSocket};
+use crate::server::waiting_users::WaitingUser;
+use axum::extract::ws::Message;
 use futures_util::SinkExt;
 use futures_util::StreamExt;
 
 /// Holds the client-server connections between two peers.
 pub struct Connection {
-    left: WebSocket,
-    right: WebSocket,
+    left: WaitingUser,
+    right: WaitingUser,
 }
 
 impl Connection {
-    pub fn new(left: WebSocket, right: WebSocket) -> Self {
+    pub fn new(left: WaitingUser, right: WaitingUser) -> Self {
         Self { left, right }
     }
 
@@ -19,11 +20,17 @@ impl Connection {
         tracing::info!("communication starting between a pair");
         let msg = "connected to peer!".to_string();
 
-        let (mut left_tx, mut left_rx) = self.left.split();
-        let (mut right_tx, mut right_rx) = self.right.split();
+        let (mut left_tx, mut left_rx) = self.left.socket.split();
+        let (mut right_tx, mut right_rx) = self.right.socket.split();
 
         let _ = right_tx.send(SocketMessage::info_msg(msg.clone())).await;
         let _ = left_tx.send(SocketMessage::info_msg(msg)).await;
+        let _ = right_tx
+            .send(SocketMessage::peer_scores(self.left.scores))
+            .await;
+        let _ = left_tx
+            .send(SocketMessage::peer_scores(self.right.scores))
+            .await;
 
         loop {
             tokio::select! {

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1,17 +1,17 @@
 use crate::common::SocketMessage;
-use crate::server::waiting_users::WaitingUser;
+use crate::server::User;
 use axum::extract::ws::Message;
 use futures_util::SinkExt;
 use futures_util::StreamExt;
 
 /// Holds the client-server connections between two peers.
 pub struct Connection {
-    left: WaitingUser,
-    right: WaitingUser,
+    left: User,
+    right: User,
 }
 
 impl Connection {
-    pub fn new(left: WaitingUser, right: WaitingUser) -> Self {
+    pub fn new(left: User, right: User) -> Self {
         Self { left, right }
     }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -91,10 +91,10 @@ pub async fn run() {
         .init();
     let tracing_layer = TraceLayer::new_for_http();
 
+    tracing::info!("starting server ");
     let state = State::new();
     state.start_pairing().await;
 
-    tracing::info!("starting server ");
     let cors = CorsLayer::new()
         .allow_origin(Any)
         .allow_methods(Any)

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -33,9 +33,9 @@ impl State {
 
     /// Queues a user for pairing. Await the oneshot receiver and
     /// you will receive the peer ID when pairing has completed.
-    async fn queue(&self, score: Scores, socket: WebSocket) {
+    async fn queue(&self, scores: Scores, socket: WebSocket) {
         tracing::info!("user queued ");
-        let user = WaitingUser { score, socket };
+        let user = WaitingUser { scores, socket };
         self.waiting_users.queue(user).await;
     }
 
@@ -47,7 +47,7 @@ impl State {
                 {
                     while let Some((left, right)) = users.pop_pair().await {
                         tokio::spawn(async move {
-                            Connection::new(left.socket, right.socket).run().await;
+                            Connection::new(left, right).run().await;
                         });
                     }
                 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -10,7 +10,6 @@ use axum::{
 use crate::common::Scores;
 use crate::common::CONFIG;
 use crate::server::connection::Connection;
-use crate::server::waiting_users::WaitingUser;
 use crate::server::waiting_users::WaitingUsers;
 use std::sync::Arc;
 use tower_http::cors::{Any, CorsLayer};
@@ -19,6 +18,11 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 mod connection;
 mod waiting_users;
+
+pub struct User {
+    pub scores: Scores,
+    pub socket: WebSocket,
+}
 
 #[derive(Default, Clone)]
 struct State {
@@ -35,7 +39,7 @@ impl State {
     /// you will receive the peer ID when pairing has completed.
     async fn queue(&self, scores: Scores, socket: WebSocket) {
         tracing::info!("user queued ");
-        let user = WaitingUser { scores, socket };
+        let user = User { scores, socket };
         self.waiting_users.queue(user).await;
     }
 

--- a/src/server/waiting_users.rs
+++ b/src/server/waiting_users.rs
@@ -29,7 +29,7 @@ impl WaitingUsers {
         let mut closest = f32::MAX;
 
         for (index, user) in users.iter().enumerate() {
-            let diff = left.score.distance(&user.score);
+            let diff = left.scores.distance(&user.scores);
             if diff < closest {
                 closest = diff;
                 right_index = index;
@@ -44,6 +44,6 @@ impl WaitingUsers {
 }
 
 pub struct WaitingUser {
-    pub score: Scores,
+    pub scores: Scores,
     pub socket: WebSocket,
 }

--- a/src/server/waiting_users.rs
+++ b/src/server/waiting_users.rs
@@ -1,19 +1,18 @@
-use crate::common::Scores;
-use axum::extract::ws::WebSocket;
+use crate::server::User;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
 #[derive(Default, Clone)]
-pub struct WaitingUsers(Arc<Mutex<Vec<WaitingUser>>>);
+pub struct WaitingUsers(Arc<Mutex<Vec<User>>>);
 
 impl WaitingUsers {
-    pub async fn queue(&self, user: WaitingUser) {
+    pub async fn queue(&self, user: User) {
         self.0.lock().await.push(user);
     }
 
     /// If 2 or more users are present, it'll pop the longest-waiting user along with
     /// another user who has the closest personality.
-    pub async fn pop_pair(&self) -> Option<(WaitingUser, WaitingUser)> {
+    pub async fn pop_pair(&self) -> Option<(User, User)> {
         let mut users = self.0.lock().await;
 
         let len = users.len();
@@ -41,9 +40,4 @@ impl WaitingUsers {
         tracing::info!("two users paired up!");
         Some((left, right))
     }
-}
-
-pub struct WaitingUser {
-    pub scores: Scores,
-    pub socket: WebSocket,
 }

--- a/src/server/waiting_users.rs
+++ b/src/server/waiting_users.rs
@@ -7,7 +7,9 @@ pub struct WaitingUsers(Arc<Mutex<Vec<User>>>);
 
 impl WaitingUsers {
     pub async fn queue(&self, user: User) {
-        self.0.lock().await.push(user);
+        let mut lock = self.0.lock().await;
+        lock.push(user);
+        tracing::info!("users waiting for peer: {}", lock.len());
     }
 
     /// If 2 or more users are present, it'll pop the longest-waiting user along with
@@ -16,7 +18,6 @@ impl WaitingUsers {
         let mut users = self.0.lock().await;
 
         let len = users.len();
-        tracing::info!("users waiting {}", len);
         if len < 2 {
             return None;
         }
@@ -38,6 +39,8 @@ impl WaitingUsers {
         let right = users.remove(right_index);
 
         tracing::info!("two users paired up!");
+        tracing::info!("remaining users: {}", users.len());
+
         Some((left, right))
     }
 }


### PR DESCRIPTION
Since the entire point of the app is about the personality diff, it makes sense the client should have access to the peer's score for comparing it.