### PR TITLE
feat(server): Avoid double-queing same user

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -119,18 +119,10 @@ impl State {
                             // If they're the same user, put the newest connection back in queue
                             // (if pingable).
                             if right.id == left.id {
-                                tracing::error!("same user connecting twice");
-                                if right.con_time > left.con_time && right_pinged {
-                                    tracing::info!("pushing back user: {}", &right.id);
-                                    users.queue(right).await;
-                                    tracing::info!("closing user: {}", &left.id);
-                                    let _ = left.socket.close().await;
-                                } else if right.con_time < left.con_time && left_pinged {
-                                    tracing::info!("pushing back user: {}", &left.id);
-                                    users.queue(left).await;
-                                    tracing::info!("closing user: {}", &right.id);
-                                    let _ = right.socket.close().await;
-                                }
+                                tracing::error!("same user connecting twice: {}", &right.id);
+                                let _ = right.socket.close().await;
+                                let _ = left.socket.close().await;
+
                                 return;
                             }
 


### PR DESCRIPTION
* Ensure user is not already present when queing user. 
* When double-user detected, close both connections instead of trying to guess which one is more relevant to be open. 

While it's more ideal to figure out which one is the good one, it also leads to more confusion and state