### PR TITLE
fix(client): Persistent ID

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -258,6 +258,7 @@ impl State {
         scores: Scores,
         peer_score_signal: Signal<Option<Scores>>,
         is_disconnected: bool,
+        id: Uuid,
     ) -> Result<(), String> {
         let chat = self.inner.lock().unwrap().chat.clone();
         let mut lock = chat.inner.lock().unwrap();
@@ -273,7 +274,7 @@ impl State {
         }
 
         if is_disconnected {
-            let ws = connect_to_peer(scores, chat.clone(), peer_score_signal).await?;
+            let ws = connect_to_peer(scores, chat.clone(), peer_score_signal, id).await?;
             lock.socket = Some(ws);
         } else {
             lock.send_message(SocketMessage::StateChange(ChangeState::Waiting));

--- a/src/client/pages/chat.rs
+++ b/src/client/pages/chat.rs
@@ -157,10 +157,11 @@ fn form_group(
                         }
 
                         let thestate = state.clone();
+                        let id = thestate.id();
                         let status = thestate.inner.lock().unwrap().chat.inner.lock().unwrap().status.clone();
                         let is_disconnected = status() == UserStatus::Disconnected;
                         spawn_local(async move {
-                            thestate.new_peer(scores, peer_score.clone(), is_disconnected).await.unwrap();
+                            thestate.new_peer(scores, peer_score.clone(), is_disconnected, id).await.unwrap();
                         });
                     },
                     background_color: if !enabled {"gray"} else {""},
@@ -304,12 +305,13 @@ fn disabled_chat(
                     onclick: move |_| {
                                 let state = state.clone();
                                 let state = state.clone();
+                                let id = state.id();
                                 let mut status = state.inner.lock().unwrap().chat.inner.lock().unwrap().status.clone();
                                 let is_disconnected = status() == UserStatus::Disconnected;
                                 *status.write() = UserStatus::Waiting;
 
                                 spawn_local(async move {
-                                    state.new_peer(scores, peer_score.clone(), is_disconnected).await.unwrap();
+                                    state.new_peer(scores, peer_score.clone(), is_disconnected, id).await.unwrap();
                                 });
                     },
                     "Start chatting!"

--- a/src/client/utils.rs
+++ b/src/client/utils.rs
@@ -252,14 +252,10 @@ pub async fn connect_to_peer(
     scores: Scores,
     mut state: ChatState,
     peer_score_signal: Signal<Option<Scores>>,
+    id: Uuid,
 ) -> Result<WebSocket, String> {
     log_to_console("Starting to connect");
-    let url = format!(
-        "{}/pair/{}/{}",
-        CONFIG.server_address(),
-        scores,
-        crate::client::get_id().simple().to_string()
-    );
+    let url = format!("{}/pair/{}/{}", CONFIG.server_address(), scores, id,);
 
     // Attempt to create the WebSocket
     let ws = web_sys::WebSocket::new(&url).map_err(|err| {


### PR DESCRIPTION
there was a bug where whne you connected it'd create a new ID because for some reason it couldn't read from the local storage?
