### PR TITLE
ref: Remove ping/pong types

### DIFF
--- a/src/client/utils.rs
+++ b/src/client/utils.rs
@@ -288,7 +288,8 @@ pub async fn connect_to_peer(
                     log_to_console(("status: ", status));
                     return;
                 }
-                SM::Ping | SM::Pong | SM::StateChange(_) | SM::GetStatus => {
+                // These are only supposed to go from the client to the server.
+                SM::StateChange(_) | SM::GetStatus => {
                     log_to_console(("unexpected socketmessage", txt));
                     return;
                 }

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -42,8 +42,6 @@ pub enum SocketMessage {
     PeerScores(Scores),
     ConnectionClosed,
     GetStatus,
-    Ping,
-    Pong,
 }
 
 impl SocketMessage {
@@ -85,10 +83,6 @@ impl SocketMessage {
     pub fn close_connection() -> Message {
         Message::Text(SocketMessage::ConnectionClosed.to_string())
     }
-
-    pub fn ping() -> Message {
-        Message::Text(SocketMessage::Ping.to_string())
-    }
 }
 
 /// Messages being sent from the client to the server.
@@ -100,19 +94,5 @@ impl SocketMessage {
 
     pub fn get_status() -> Vec<u8> {
         Self::GetStatus.to_bytes()
-    }
-
-    pub fn ping() -> Vec<u8> {
-        let mut writer: Vec<u8> = vec![];
-        let val = Self::Ping;
-        serde_json::to_writer(&mut writer, &val).unwrap();
-        writer
-    }
-
-    pub fn pong() -> Vec<u8> {
-        let mut writer: Vec<u8> = vec![];
-        let val = Self::Pong;
-        serde_json::to_writer(&mut writer, &val).unwrap();
-        writer
     }
 }

--- a/src/server/user.rs
+++ b/src/server/user.rs
@@ -95,11 +95,6 @@ fn handle_socket(
                                     let upmsg = StateMessage {id: id.clone(), action: StateAction::StateChange(new_state)};
                                     logerr!(upsender.send(upmsg).await, continue);
                                 },
-                                Ok(SocketMessage::Ping) => {
-                                    timeout.as_mut().reset(Instant::now() + timeout_duration);
-                                    let x = tx.send(SocketMessage::Ping.into_message()).await;
-                                    tracing::info!("sending ping: {:?}", &x);
-                                },
                                 Ok(socket_message) => {
                                     let _ = sender.send(socket_message).await;
                                 },
@@ -194,4 +189,3 @@ impl User {
         false
     }
 }
-


### PR DESCRIPTION
no longer needed, we use the getstatus thing to ensure client is still there (as well as for getting the status :P) 
